### PR TITLE
Update nodemon configuration to run node in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ docker-compose down && docker-compose build && docker-compose up
 
 *NOTE*: The first build will be slow due to docker world-building
 
-This will host your front end on `localhost:3001`, your api endpoint on `localhost:3002`, and mongodb will be networked internally (more details TBD)
+This will host your front end on `localhost:3001`, your api endpoint on `localhost:3002`, and mongodb will be networked internally (more details TBD). You can connect a 
+remote debugger to `0.0.0.0:56745` in order to debug the api. 
 
 The frontend and backend will auto-refresh as you make changes, and the only time you will ever need to re-run `docker-compose down && docker-compose build && docker-compose up` 
 is if you made changes to the package.json file in either ui or api.

--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["src"],
+  "ext": "js",
+  "ignore": ["src/**/*.test.js"],
+  "exec": "node --inspect=0.0.0.0:56745 ./src/app.js"
+}

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -3,5 +3,5 @@
 if [ $NODE_ENV = "production" ]; then
   node src/app.js;
 else
-  nodemon src/app.js;
+  nodemon
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: dockerfile.dev
     ports:
       - "3002:3002"
+      - "56745:56745"
     volumes:
       - ./api:/api
       - /api/node_modules


### PR DESCRIPTION
# Enable Remote Debugging

### What was the feature/problem?

Unable to set breakpoints to debug api application while running in Docker.

### How does this PR address the above feature/problem?

This change causes the api to run in debug mode and exposes the debug port through the
docker-compose configuration. This will allow developers to connect a remote debugging session
using tools such as WebStorm/VSCode. 

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

